### PR TITLE
use SSL/TLS in DOI-URLs

### DIFF
--- a/RNeXML/R/nexml_publish.R
+++ b/RNeXML/R/nexml_publish.R
@@ -78,7 +78,7 @@ nexml_figshare <- function(nexml,
   }
 
 
-  doi <- paste("http://doi.org/10.6084/m9.figshare", id, sep=".")
+  doi <- paste("https://doi.org/10.6084/m9.figshare", id, sep=".")
 
   rfigshare::fs_add_authors(id, authors = m[["dc:creator"]])
   rfigshare::fs_add_categories(id, categories)

--- a/afex/R/aov_car.R
+++ b/afex/R/aov_car.R
@@ -121,7 +121,7 @@
 #'
 #' \code{\link{mixed}} provides a (formula) interface for obtaining p-values for mixed-models via \pkg{lme4}.
 #'
-#' @references Cramer, A. O. J., van Ravenzwaaij, D., Matzke, D., Steingroever, H., Wetzels, R., Grasman, R. P. P. P., ... Wagenmakers, E.-J. (2015). Hidden multiplicity in exploratory multiway ANOVA: Prevalence and remedies.  \emph{Psychonomic Bulletin & Review}, 1–8. doi:\href{http://doi.org/10.3758/s13423-015-0913-5}{10.3758/s13423-015-0913-5} 
+#' @references Cramer, A. O. J., van Ravenzwaaij, D., Matzke, D., Steingroever, H., Wetzels, R., Grasman, R. P. P. P., ... Wagenmakers, E.-J. (2015). Hidden multiplicity in exploratory multiway ANOVA: Prevalence and remedies.  \emph{Psychonomic Bulletin & Review}, 1–8. doi:\href{https://doi.org/10.3758/s13423-015-0913-5}{10.3758/s13423-015-0913-5} 
 #' 
 #' Maxwell, S. E., & Delaney, H. D. (2004). \emph{Designing Experiments and Analyzing Data: A Model-Comparisons Perspective}. Mahwah, N.J.: Lawrence Erlbaum Associates.
 #'

--- a/afex/R/ks2013.3-data.R
+++ b/afex/R/ks2013.3-data.R
@@ -12,9 +12,9 @@
 #' @name ks2013.3
 #' @usage ks2013.3
 #' @format A data.frame with 1440 rows and 6 variables.
-#' @source Klauer, K. C., & Singmann, H. (2013). Does logic feel good? Testing for intuitive detection of logicality in syllogistic reasoning. Journal of Experimental Psychology: Learning, Memory, and Cognition, 39(4), 1265-1273. http://doi.org/10.1037/a0030530
+#' @source Klauer, K. C., & Singmann, H. (2013). Does logic feel good? Testing for intuitive detection of logicality in syllogistic reasoning. Journal of Experimental Psychology: Learning, Memory, and Cognition, 39(4), 1265-1273. https://doi.org/10.1037/a0030530
 #' 
-#' Morsanyi, K., & Handley, S. J. (2012). Logic feels so good-I like it! Evidence for intuitive detection of logicality in syllogistic reasoning. Journal of Experimental Psychology: Learning, Memory, and Cognition, 38(3), 596-616. http://doi.org/10.1037/a0026099
+#' Morsanyi, K., & Handley, S. J. (2012). Logic feels so good-I like it! Evidence for intuitive detection of logicality in syllogistic reasoning. Journal of Experimental Psychology: Learning, Memory, and Cognition, 38(3), 596-616. https://doi.org/10.1037/a0026099
 #' 
 #' 
 #' 

--- a/afex/R/methods.afex_aov.R
+++ b/afex/R/methods.afex_aov.R
@@ -21,7 +21,7 @@
 #' \code{p.adjust.method} defaults to the method specified in the call to \code{\link{aov_car}} in \code{anova_table}. If no method was specified and \code{p.adjust.method = NULL} p-values are not adjusted.
 #' 
 #' @references 
-#' Cramer, A. O. J., van Ravenzwaaij, D., Matzke, D., Steingroever, H., Wetzels, R., Grasman, R. P. P. P., ... Wagenmakers, E.-J. (2015). Hidden multiplicity in exploratory multiway ANOVA: Prevalence and remedies.  \emph{Psychonomic Bulletin & Review}, 1–8. doi:\href{http://doi.org/10.3758/s13423-015-0913-5}{10.3758/s13423-015-0913-5}
+#' Cramer, A. O. J., van Ravenzwaaij, D., Matzke, D., Steingroever, H., Wetzels, R., Grasman, R. P. P. P., ... Wagenmakers, E.-J. (2015). Hidden multiplicity in exploratory multiway ANOVA: Prevalence and remedies.  \emph{Psychonomic Bulletin & Review}, 1–8. doi:\href{https://doi.org/10.3758/s13423-015-0913-5}{10.3758/s13423-015-0913-5}
 #' 
 #' @name afex_aov-methods
 #' @importFrom stats p.adjust

--- a/afex/R/nice.R
+++ b/afex/R/nice.R
@@ -32,7 +32,7 @@
 #'
 #' @references Bakeman, R. (2005). Recommended effect size statistics for repeated measures designs. \emph{Behavior Research Methods}, 37(3), 379-384. doi:10.3758/BF03192707
 #'
-#' Cramer, A. O. J., van Ravenzwaaij, D., Matzke, D., Steingroever, H., Wetzels, R., Grasman, R. P. P. P., ... Wagenmakers, E.-J. (2015). Hidden multiplicity in exploratory multiway ANOVA: Prevalence and remedies.  \emph{Psychonomic Bulletin & Review}, 1–8. doi:\href{http://doi.org/10.3758/s13423-015-0913-5}{10.3758/s13423-015-0913-5}
+#' Cramer, A. O. J., van Ravenzwaaij, D., Matzke, D., Steingroever, H., Wetzels, R., Grasman, R. P. P. P., ... Wagenmakers, E.-J. (2015). Hidden multiplicity in exploratory multiway ANOVA: Prevalence and remedies.  \emph{Psychonomic Bulletin & Review}, 1–8. doi:\href{https://doi.org/10.3758/s13423-015-0913-5}{10.3758/s13423-015-0913-5}
 #'
 #' Olejnik, S., & Algina, J. (2003). Generalized Eta and Omega Squared Statistics: Measures of Effect Size for Some Common Research Designs. \emph{Psychological Methods}, 8(4), 434-447. doi:10.1037/1082-989X.8.4.434
 #' 

--- a/bayesGDS/R/bayesGDS-package.R
+++ b/bayesGDS/R/bayesGDS-package.R
@@ -5,7 +5,7 @@
 #' @description Functions for implementing
 #' the Braun and Damien (BD) Scalable Rejection Sampling algorthm
 #' @references
-#' Braun, Michael and Paul Damien (2015).  Scalable Rejection Sampling for Bayesian Hierarchical Models. Marketing Science. Articles in Advance.  http://doi.org/10.1287/mksc.2014.0901
+#' Braun, Michael and Paul Damien (2015).  Scalable Rejection Sampling for Bayesian Hierarchical Models. Marketing Science. Articles in Advance.  https://doi.org/10.1287/mksc.2014.0901
 #' @import Matrix
 #' @importFrom stats runif
 #' @encoding UTF-8

--- a/bayesGDS/R/sample.R
+++ b/bayesGDS/R/sample.R
@@ -61,7 +61,7 @@
 #' @references
 #' Braun, Michael and Paul Damien (2015).  Scalable Rejection Sampling for
 #' Bayesian Hierarchical Models. Marketing Science. Articles in Advance.
-#' http://doi.org/10.1287/mksc.2014.0901
+#' https://doi.org/10.1287/mksc.2014.0901
 #' @export
 sample.GDS <- function(n.draws, log.phi, post.mode, fn.dens.post,
                        fn.dens.prop, fn.draw.prop,

--- a/coenocliner/R/jamil-sim.R
+++ b/coenocliner/R/jamil-sim.R
@@ -37,7 +37,7 @@
 ##'
 ##' @export
 ##'
-##' @references Jamil and ter Braak (2013) Generalized linear mixed models can detect unimodal species-environment relationships. \emph{PeerJ} \strong{1:e95}; DOI \href{http://doi.org/10.7717/peerj.95}{10.7717/peerj.95}.
+##' @references Jamil and ter Braak (2013) Generalized linear mixed models can detect unimodal species-environment relationships. \emph{PeerJ} \strong{1:e95}; DOI \href{https://doi.org/10.7717/peerj.95}{10.7717/peerj.95}.
 ##'
 ##' @examples
 ##' set.seed(42)

--- a/dtwclust/R/NCCc.R
+++ b/dtwclust/R/NCCc.R
@@ -7,7 +7,7 @@
 #'
 #' Paparrizos J and Gravano L (2015). ``k-Shape: Efficient and Accurate Clustering of Time Series.''
 #' In \emph{Proceedings of the 2015 ACM SIGMOD International Conference on Management of Data},
-#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{http://doi.org/10.1145/2723372.2737793}.
+#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{https://doi.org/10.1145/2723372.2737793}.
 #'
 #' @seealso
 #'

--- a/dtwclust/R/SBD.R
+++ b/dtwclust/R/SBD.R
@@ -40,7 +40,7 @@
 #'
 #' Paparrizos J and Gravano L (2015). ``k-Shape: Efficient and Accurate Clustering of Time Series.''
 #' In \emph{Proceedings of the 2015 ACM SIGMOD International Conference on Management of Data},
-#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{http://doi.org/10.1145/2723372.2737793}.
+#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{https://doi.org/10.1145/2723372.2737793}.
 #'
 #' @param x,y A time series.
 #' @param znorm Logical. Should each series be z-normalized before calculating the distance?

--- a/dtwclust/R/dtwclust.R
+++ b/dtwclust/R/dtwclust.R
@@ -255,7 +255,7 @@
 #'
 #' Sakoe H and Chiba S (1978). ``Dynamic programming algorithm optimization for spoken word
 #' recognition.'' \emph{Acoustics, Speech and Signal Processing, IEEE Transactions on},
-#' \strong{26}(1), pp. 43-49. ISSN 0096-3518, \url{http://doi.org/10.1109/TASSP.1978.1163055}.
+#' \strong{26}(1), pp. 43-49. ISSN 0096-3518, \url{https://doi.org/10.1109/TASSP.1978.1163055}.
 #'
 #' Ratanamahatana A and Keogh E (2004). ``Everything you know about dynamic time warping is wrong.''
 #' In \emph{3rd Workshop on Mining Temporal and Sequential Data, in conjunction with 10th ACM SIGKDD
@@ -268,7 +268,7 @@
 #'
 #' Paparrizos J and Gravano L (2015). ``k-Shape: Efficient and Accurate Clustering of Time Series.''
 #' In \emph{Proceedings of the 2015 ACM SIGMOD International Conference on Management of Data},
-#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{http://doi.org/10.1145/2723372.2737793}.
+#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{https://doi.org/10.1145/2723372.2737793}.
 #'
 #' @example inst/dtwclust-examples.R
 #'

--- a/dtwclust/R/pkg.R
+++ b/dtwclust/R/pkg.R
@@ -69,7 +69,7 @@
 #'
 #' Paparrizos J and Gravano L (2015). ``k-Shape: Efficient and Accurate Clustering of Time Series.''
 #' In \emph{Proceedings of the 2015 ACM SIGMOD International Conference on Management of Data},
-#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{http://doi.org/10.1145/2723372.2737793}.
+#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{https://doi.org/10.1145/2723372.2737793}.
 #'
 #' Petitjean F, Ketterlin A and Gancarski P (2011). ``A global averaging method for dynamic time
 #' warping, with applications to clustering.'' \emph{Pattern Recognition}, \strong{44}(3), pp. 678 -
@@ -78,12 +78,12 @@
 #'
 #' Sakoe H and Chiba S (1978). ``Dynamic programming algorithm optimization for spoken word
 #' recognition.'' \emph{Acoustics, Speech and Signal Processing, IEEE Transactions on},
-#' \strong{26}(1), pp. 43-49. ISSN 0096-3518, \url{http://doi.org/10.1109/TASSP.1978.1163055}.
+#' \strong{26}(1), pp. 43-49. ISSN 0096-3518, \url{https://doi.org/10.1109/TASSP.1978.1163055}.
 #'
 #' Wang X, Mueen A, Ding H, Trajcevski G, Scheuermann P and Keogh E (2013). ``Experimental comparison
 #' of representation methods and distance measures for time series data.'' \emph{Data Mining and
 #' Knowledge Discovery}, \strong{26}(2), pp. 275-309. ISSN 1384-5810,
-#' \url{http://doi.org/10.1007/s10618-012-0250-5}, \url{http://dx.doi.org/10.1007/s10618-012-0250-5}.
+#' \url{https://doi.org/10.1007/s10618-012-0250-5}, \url{http://dx.doi.org/10.1007/s10618-012-0250-5}.
 #'
 #' Bedzek, J.C. (1981). Pattern recognition with fuzzy objective function algorithms.
 #'

--- a/dtwclust/R/shape-extraction.R
+++ b/dtwclust/R/shape-extraction.R
@@ -22,7 +22,7 @@
 #'
 #' Paparrizos J and Gravano L (2015). ``k-Shape: Efficient and Accurate Clustering of Time Series.''
 #' In \emph{Proceedings of the 2015 ACM SIGMOD International Conference on Management of Data},
-#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{http://doi.org/10.1145/2723372.2737793}.
+#' series SIGMOD '15, pp. 1855-1870. ISBN 978-1-4503-2758-9, \url{https://doi.org/10.1145/2723372.2737793}.
 #'
 #' @examples
 #'

--- a/eemR/R/eem_correction.R
+++ b/eemR/R/eem_correction.R
@@ -9,7 +9,7 @@
 #'
 #' @references Murphy, K. R., Stedmon, C. a., Graeber, D., & Bro, R. (2013).
 #'   Fluorescence spectroscopy and multi-way techniques. PARAFAC. Analytical
-#'   Methods, 5(23), 6557. http://doi.org/10.1039/c3ay41160e
+#'   Methods, 5(23), 6557. https://doi.org/10.1039/c3ay41160e
 #'
 #'   \url{http://xlink.rsc.org/?DOI=c3ay41160e}
 #'
@@ -145,11 +145,11 @@ eem_remove_blank <- function(eem, blank = NA) {
 #' Lakowicz, J. R. (2006). Principles of Fluorescence Spectroscopy.
 #' Boston, MA: Springer US.#'
 #'
-#' \url{http://doi.org/10.1007/978-0-387-46312-4}
+#' \url{https://doi.org/10.1007/978-0-387-46312-4}
 #'
 #' Murphy, K. R., Stedmon, C. a., Graeber, D., & Bro, R. (2013).
 #' Fluorescence spectroscopy and multi-way techniques. PARAFAC. Analytical
-#' Methods, 5(23), 6557. http://doi.org/10.1039/c3ay41160e#'
+#' Methods, 5(23), 6557. https://doi.org/10.1039/c3ay41160e#'
 #'
 #'  \url{http://xlink.rsc.org/?DOI=c3ay41160e}
 #'
@@ -262,7 +262,7 @@ eem_remove_scattering <- function(eem, type, order = 1, width = 10){
 #' Lawaetz, A. J., & Stedmon, C. A. (2009). Fluorescence Intensity Calibration
 #' Using the Raman Scatter Peak of Water. Applied Spectroscopy, 63(8), 936-940.
 #'
-#' \url{http://doi.org/10.1366/000370209788964548}
+#' \url{https://doi.org/10.1366/000370209788964548}
 #'
 #' Murphy, K. R., Stedmon, C. a., Graeber, D., & Bro, R. (2013). Fluorescence
 #' spectroscopy and multi-way techniques. PARAFAC. Analytical Methods, 5(23),
@@ -404,12 +404,12 @@ eem_raman_normalisation <- function(eem, blank = NA) {
 #'
 #' @references Parker, C. a., & Barnes, W. J. (1957). Some experiments with
 #'   spectrofluorimeters and filter fluorimeters. The Analyst, 82(978), 606.
-#'   \url{http://doi.org/10.1039/an9578200606}
+#'   \url{https://doi.org/10.1039/an9578200606}
 #'
 #'   Kothawala, D. N., Murphy, K. R., Stedmon, C. A., Weyhenmeyer, G. A., &
 #'   Tranvik, L. J. (2013). Inner filter correction of dissolved organic matter
 #'   fluorescence. Limnology and Oceanography: Methods, 11(12), 616-630.
-#'   \url{http://doi.org/10.4319/lom.2013.11.616}
+#'   \url{https://doi.org/10.4319/lom.2013.11.616}
 #'
 #' @return An object of class \code{eem} containing: \itemize{ \item sample The
 #'   file name of the eem. \item x A matrix with fluorescence values. \item em

--- a/eemR/R/eem_metrics.R
+++ b/eemR/R/eem_metrics.R
@@ -79,7 +79,7 @@ eem_fluorescence_index <- function(eem, verbose = TRUE){
 #'   DOM in seawater using excitation-emission matrix spectroscopy. Marine
 #'   Chemistry, 51(4), 325-346.
 #'
-#'   \url{http://doi.org/10.1016/0304-4203(95)00062-3}
+#'   \url{https://doi.org/10.1016/0304-4203(95)00062-3}
 #'
 #' @examples
 #' file <- system.file("extdata/cary/scans_day_1/", "sample1.csv", package = "eemR")
@@ -153,7 +153,7 @@ eem_coble_peaks <- function(eem, verbose = TRUE){
 #'   Determining the Humification Index of Dissolved Organic Matter.
 #'   Environmental Science & Technology, 36(4), 742-746.
 #'
-#'   \url{http://doi.org/10.1021/es0155276}
+#'   \url{https://doi.org/10.1021/es0155276}
 #'
 #' @return A data frame containing the humification index (HIX) for each eem.
 #' @export
@@ -225,7 +225,7 @@ eem_humification_index <- function(eem, scale = FALSE, verbose = TRUE) {
 #'   J. M., & Parlanti, E. (2009). Properties of fluorescent dissolved organic
 #'   matter in the Gironde Estuary. Organic Geochemistry, 40(6), 706-719.
 #'
-#'   \url{http://doi.org/10.1016/j.orggeochem.2009.03.002}
+#'   \url{https://doi.org/10.1016/j.orggeochem.2009.03.002}
 #'
 #' @return A data frame containing the biological index (BIX) for each eem.
 #' @export

--- a/island/R/island.R
+++ b/island/R/island.R
@@ -37,10 +37,10 @@
 #'   Letters}, \bold{18}, 451--461. \cr \cr Simberloff, D. S., and Wilson, E.
 #'   O.. (1969). Experimental Zoogeography of Islands: The Colonization of Empty
 #'   Islands. \emph{Ecology}, \bold{50(2)}, 278--296.
-#'   \url{http://doi.org/10.2307/1934856} \cr \cr Simberloff, D. S.. (1969).
+#'   \url{https://doi.org/10.2307/1934856} \cr \cr Simberloff, D. S.. (1969).
 #'   Experimental Zoogeography of Islands: A Model for Insular Colonization.
 #'   \emph{Ecology}, \bold{50(2)}, 296--314.
-#'   \url{http://doi.org/10.2307/1934857}
+#'   \url{https://doi.org/10.2307/1934857}
 #'
 #' @docType package
 #' @name island

--- a/island/R/simberloff.R
+++ b/island/R/simberloff.R
@@ -31,20 +31,20 @@
 #'
 #' @source Simberloff, D. S., & Wilson, E. O.. (1969). Experimental Zoogeography
 #'   of Islands: The Colonization of Empty Islands. \emph{Ecology},
-#'   \bold{50(2)}, 278--296. \url{http://doi.org/10.2307/1934856}
+#'   \bold{50(2)}, 278--296. \url{https://doi.org/10.2307/1934856}
 #'
 #' @references Wilson, E. O.. (2010). Island Biogeography in the 1960s: THEORY
 #'   AND EXPERIMENT. In J. B. Losos and R. E. Ricklefs (Eds.), \emph{The Theory
 #'   of Island Biogeography Revisited} (pp. 1--12). Princeton University Press.
 #'   \cr \cr Simberloff, D. S., and Wilson, E. O.. (1969). Experimental
 #'   Zoogeography of Islands: The Colonization of Empty Islands. \emph{Ecology},
-#'   \bold{50(2)}, 278--296. \url{http://doi.org/10.2307/1934856} \cr \cr
+#'   \bold{50(2)}, 278--296. \url{https://doi.org/10.2307/1934856} \cr \cr
 #'   Wilson, E. O., and Simberloff, D. S.. (1969). Experimental Zoogeography of
 #'   Islands: Defaunation and Monitoring Techniques. \emph{Ecology},
-#'   \bold{50(2)}, 267--278. \url{http://doi.org/10.2307/1934855} \cr \cr
+#'   \bold{50(2)}, 267--278. \url{https://doi.org/10.2307/1934855} \cr \cr
 #'   Simberloff, D. S.. (1969). Experimental Zoogeography of Islands: A Model
 #'   for Insular Colonization. \emph{Ecology}, \bold{50(2)}, 296--314.
-#'   \url{http://doi.org/10.2307/1934857}
+#'   \url{https://doi.org/10.2307/1934857}
 #'
 #' @name simberloff
 NULL

--- a/manifestoR/R/scaling_bootstrap.R
+++ b/manifestoR/R/scaling_bootstrap.R
@@ -16,7 +16,7 @@
 #' functions or numbers, where numbers are interpreted as quantiles.
 #' @param N number of resamples to use for bootstrap distribution
 #' @param ... more arguments passed on to \code{fun}
-#' @references Benoit, K., Laver, M., & Mikhaylov, S. (2009). Treating Words as Data with Error: Uncertainty in Text Statements of Policy Positions. American Journal of Political Science, 53(2), 495-513. http://doi.org/10.1111/j.1540-5907.2009.00383.x
+#' @references Benoit, K., Laver, M., & Mikhaylov, S. (2009). Treating Words as Data with Error: Uncertainty in Text Statements of Policy Positions. American Journal of Political Science, 53(2), 495-513. https://doi.org/10.1111/j.1540-5907.2009.00383.x
 #' @importFrom stats sd
 #' @export
 mp_bootstrap <- function(data,

--- a/matrixpls/R/matrixpls.R
+++ b/matrixpls/R/matrixpls.R
@@ -90,7 +90,7 @@
 #'
 #'Lohmöller J.-B. (1989) \emph{Latent variable path modeling with partial least squares.} Heidelberg: Physica-Verlag.
 #'
-#'Rönkkö, M., McIntosh, C. N., & Antonakis, J. (2015). On the adoption of partial least squares in psychological research: Caveat emptor. \emph{Personality and Individual Differences}, (87), 76–84. \href{http://doi.org/10.1016/j.paid.2015.07.019}{DOI:10.1016/j.paid.2015.07.019}
+#'Rönkkö, M., McIntosh, C. N., & Antonakis, J. (2015). On the adoption of partial least squares in psychological research: Caveat emptor. \emph{Personality and Individual Differences}, (87), 76–84. \href{https://doi.org/10.1016/j.paid.2015.07.019}{DOI:10.1016/j.paid.2015.07.019}
 #'
 #'Wold, H. (1982). Soft modeling - The Basic Design And Some Extensions. In K. G. Jöreskog & S. Wold (Eds.),\emph{Systems under indirect observation: causality, structure, prediction} (pp. 1–54). Amsterdam: North-Holland.
 #'

--- a/matrixpls/R/matrixpls.boot.R
+++ b/matrixpls/R/matrixpls.boot.R
@@ -68,9 +68,9 @@
 #'
 #'Henseler, J., Ringle, C. M., & Sinkovics, R. R. (2009). The use of partial least squares path modeling in international marketing. \emph{Advances in International Marketing}, 20, 277–319.
 #'
-#'Rönkkö, M., & Evermann, J. (2013). A critical examination of common beliefs about partial least squares path modeling. \emph{Organizational Research Methods}, 16(3), 425–448. http://doi.org/10.1177/1094428112474693
+#'Rönkkö, M., & Evermann, J. (2013). A critical examination of common beliefs about partial least squares path modeling. \emph{Organizational Research Methods}, 16(3), 425–448. https://doi.org/10.1177/1094428112474693
 #'
-#'Rönkkö, M., McIntosh, C. N., & Antonakis, J. (2015). On the adoption of partial least squares in psychological research: Caveat emptor. \emph{Personality and Individual Differences}, (87), 76–84. http://doi.org/10.1016/j.paid.2015.07.019
+#'Rönkkö, M., McIntosh, C. N., & Antonakis, J. (2015). On the adoption of partial least squares in psychological research: Caveat emptor. \emph{Personality and Individual Differences}, (87), 76–84. https://doi.org/10.1016/j.paid.2015.07.019
 #'
 #'
 matrixpls.boot <- function(data, ..., R = 500,

--- a/matrixpls/R/matrixpls.postestimation.R
+++ b/matrixpls/R/matrixpls.postestimation.R
@@ -506,7 +506,7 @@ loadings <- function(object, ...) {
 #'
 #'Fornell, C., & Larcker, D. F. (1981). Evaluating structural equation models with unobservable variables and measurement error. \emph{Journal of marketing research}, 18(1), 39–50.
 #'
-#'Aguirre-Urreta, M. I., Marakas, G. M., & Ellis, M. E. (2013). Measurement of composite reliability in research using partial least squares: Some issues and an alternative approach. \emph{The DATA BASE for Advances in Information Systems}, 44(4), 11–43. \href{http://doi.org/10.1145/2544415.2544417}{DOI:10.1145/2544415.2544417}
+#'Aguirre-Urreta, M. I., Marakas, G. M., & Ellis, M. E. (2013). Measurement of composite reliability in research using partial least squares: Some issues and an alternative approach. \emph{The DATA BASE for Advances in Information Systems}, 44(4), 11–43. \href{https://doi.org/10.1145/2544415.2544417}{DOI:10.1145/2544415.2544417}
 #'
 #'@export
 #'

--- a/matrixpls/R/matrixpls.signChangeCorrection.R
+++ b/matrixpls/R/matrixpls.signChangeCorrection.R
@@ -44,7 +44,7 @@
 #'
 #'Rönkkö, M., McIntosh, C. N., & Antonakis, J. (2015). On the adoption of partial least squares in 
 #'psychological research: Caveat emptor. \emph{Personality and Individual Differences}, (87), 76–84.
-#'\href{http://doi.org/10.1016/j.paid.2015.07.019}{DOI:10.1016/j.paid.2015.07.019}
+#'\href{https://doi.org/10.1016/j.paid.2015.07.019}{DOI:10.1016/j.paid.2015.07.019}
 NULL
 
 #'@describeIn signChangeCorrection individual sign change correction

--- a/netdiffuseR/R/RcppExports.R
+++ b/netdiffuseR/R/RcppExports.R
@@ -231,7 +231,7 @@ rgraph_er_dyn_cpp <- function(n = 10L, t = 3L, p = 0.3, undirected = TRUE, weigh
 #' @return A sparse matrix of class \code{\link[Matrix:dgCMatrix-class]{dgCMatrix}} of size
 #' \eqn{n\times n}{n * n}.
 #' @references Watts, D. J., & Strogatz, S. H. (1998). Collective dynamics of
-#' “small-world” networks. Nature, 393(6684), 440–2. \url{http://doi.org/10.1038/30918}
+#' “small-world” networks. Nature, 393(6684), 440–2. \url{https://doi.org/10.1038/30918}
 #' @export
 #' @family simulation functions
 ring_lattice <- function(n, k, undirected = FALSE) {

--- a/netdiffuseR/R/data.R
+++ b/netdiffuseR/R/data.R
@@ -804,14 +804,14 @@
 #' @references
 #' Burt, R. S. (1987). "Social Contagion and Innovation: Cohesion versus
 #' Structural Equivalence". American Journal of Sociology, 92(6), 1287–1335.
-#' \url{http://doi.org/10.1086/228667}
+#' \url{https://doi.org/10.1086/228667}
 #'
 #' Coleman, J., Katz, E., & Menzel, H. (1966). Medical innovation: A diffusion
 #' study (2nd ed.). New York: Bobbs-Merrill
 #'
 #' Granovetter, M., & Soong, R. (1983). Threshold models of diffusion and
 #' collective behavior. The Journal of Mathematical Sociology, 9(October 2013),
-#' 165–179. \url{http://doi.org/10.1080/0022250X.1983.9989941}
+#' 165–179. \url{https://doi.org/10.1080/0022250X.1983.9989941}
 #'
 #' Rogers, E. M., Ascroft, J. R., & Röling, N. (1970). Diffusion of Innovation
 #' in Brazil, Nigeria, and India. Unpublished Report. Michigan State University,
@@ -825,11 +825,11 @@
 #'
 #' Marsden, P. V., & Friedkin, N. E. (1993). Network Studies of Social Influence.
 #' Sociological Methods & Research, 22(1), 127–151.
-#' \url{http://doi.org/10.1177/0049124193022001006}
+#' \url{https://doi.org/10.1177/0049124193022001006}
 #'
 #' Van den Bulte, C., & Iyengar, R. (2011). Tricked by Truncation: Spurious
 #' Duration Dependence and Social Contagion in Hazard Models. Marketing Science,
-#' 30(2), 233–248. \url{http://doi.org/10.1287/mksc.1100.0615}
+#' 30(2), 233–248. \url{https://doi.org/10.1287/mksc.1100.0615}
 #'
 #' Valente, T. W. (1991). Thresholds and the critical mass: Mathematical models
 #' of the diffusion of innovations. University of Southern California.

--- a/netdiffuseR/R/diffnet-methods.R
+++ b/netdiffuseR/R/diffnet-methods.R
@@ -740,7 +740,7 @@ plot_threshold.list <- function(
 #' @references
 #' Aral, S., & Walker, D. (2012). "Identifying Influential and Susceptible Members
 #' of Social Networks". Science, 337(6092), 337–341.
-#' \url{http://doi.org/10.1126/science.1215842}
+#' \url{https://doi.org/10.1126/science.1215842}
 #' @export
 #' @examples
 #' # Generating a random graph -------------------------------------------------

--- a/netdiffuseR/R/random_graph.R
+++ b/netdiffuseR/R/random_graph.R
@@ -120,10 +120,10 @@ rgraph_er <- function(n=10, t=1, p=0.3, undirected=getOption("diffnet.undirected
 #' @references
 #' Bollobás, B´., Riordan, O., Spencer, J., & Tusnády, G. (2001). The degree
 #' sequence of a scale-free random graph process. Random Structures & Algorithms,
-#' 18(3), 279–290. \url{http://doi.org/10.1002/rsa.1009}
+#' 18(3), 279–290. \url{https://doi.org/10.1002/rsa.1009}
 #'
 #' Albert-László Barabási, & Albert, R. (1999). Emergence of Scaling in Random
-#' Networks. Science, 286(5439), 509–512. \url{http://doi.org/10.1126/science.286.5439.509}
+#' Networks. Science, 286(5439), 509–512. \url{https://doi.org/10.1126/science.286.5439.509}
 #'
 #' Albert-László Barabási. (2016). Network Science: (1st ed.). Cambridge University Press.
 #' Retrieved from \url{http://barabasi.com/book/network-science}
@@ -281,7 +281,7 @@ rgraph_ba <- function(m0=1L, m=1L, t=10L, graph=NULL) {
 #' networks. Nature, 393(6684), 440–2. \url{http://dx.doi.org/10.1038/30918}
 #'
 #' Newman, M. E. J. (2003). The Structure and Function of Complex Networks.
-#' SIAM Review, 45(2), 167–256. \url{http://doi.org/10.1137/S003614450342480}
+#' SIAM Review, 45(2), 167–256. \url{https://doi.org/10.1137/S003614450342480}
 #' @author George G. Vega Yon
 #' @examples
 #'

--- a/netdiffuseR/R/rewire.R
+++ b/netdiffuseR/R/rewire.R
@@ -101,7 +101,7 @@
 #'
 #' @references
 #' Watts, D. J., & Strogatz, S. H. (1998). Collectivedynamics of "small-world" networks.
-#' Nature, 393(6684), 440–442. \url{http://doi.org/10.1038/30918}
+#' Nature, 393(6684), 440–442. \url{https://doi.org/10.1038/30918}
 #'
 #' Milo, R., Kashtan, N., Itzkovitz, S., Newman, M. E. J., & Alon, U.
 #' (2004). On the uniform generation of random graphs with prescribed degree sequences.

--- a/netdiffuseR/R/stats.R
+++ b/netdiffuseR/R/stats.R
@@ -228,7 +228,7 @@ dgr.array <- function(graph, cmode, undirected, self, valued) {
 #' @references
 #' Burt, R. S. (1987). "Social Contagion and Innovation: Cohesion versus Structural
 #' Equivalence". American Journal of Sociology, 92(6), 1287.
-#' \url{http://doi.org/10.1086/228667}
+#' \url{https://doi.org/10.1086/228667}
 #'
 #' Valente, T. W. (1995). "Network models of the diffusion of innovations"
 #'  (2nd ed.). Cresskill N.J.: Hampton Press.

--- a/netdiffuseR/R/struct_equiv.R
+++ b/netdiffuseR/R/struct_equiv.R
@@ -57,7 +57,7 @@
 #'
 #' @references Burt, R. S. (1987). "Social Contagion and Innovation: Cohesion versus
 #' Structural Equivalence". American Journal of Sociology, 92(6), 1287–1335.
-#' \url{http://doi.org/10.1086/228667}
+#' \url{https://doi.org/10.1086/228667}
 #'
 #' Valente, T. W. (1995). "Network models of the diffusion of innovations" (2nd ed.).
 #' Cresskill N.J.: Hampton Press.

--- a/poppr/R/bruvo.r
+++ b/poppr/R/bruvo.r
@@ -702,7 +702,7 @@ bruvo.msn <- function (gid, replen = 1, add = TRUE, loss = TRUE,
 #' @references Zhian N. Kamvar, Meg M. Larsen, Alan M. Kanaskie, Everett M. 
 #'   Hansen, & Niklaus J. Grünwald. Sudden_Oak_Death_in_Oregon_Forests: Spatial
 #'   and temporal population dynamics of the sudden oak death epidemic in Oregon
-#'   Forests. ZENODO, http://doi.org/10.5281/zenodo.13007, 2014.
+#'   Forests. ZENODO, https://doi.org/10.5281/zenodo.13007, 2014.
 #'   
 #'   Kamvar, Z. N., Larsen, M. M., Kanaskie, A. M., Hansen, E. M., & Grünwald,
 #'   N. J. (2015). Spatial and temporal analysis of populations of the sudden
@@ -767,7 +767,7 @@ consistent_replen <- function(index, alleles, replen){
 #' @references Zhian N. Kamvar, Meg M. Larsen, Alan M. Kanaskie, Everett M. 
 #'   Hansen, & Niklaus J. Grünwald. Sudden_Oak_Death_in_Oregon_Forests: Spatial
 #'   and temporal population dynamics of the sudden oak death epidemic in Oregon
-#'   Forests. ZENODO, http://doi.org/10.5281/zenodo.13007, 2014.
+#'   Forests. ZENODO, https://doi.org/10.5281/zenodo.13007, 2014.
 #'   
 #'   Kamvar, Z. N., Larsen, M. M., Kanaskie, A. M., Hansen, E. M., & Grünwald,
 #'   N. J. (2015). Spatial and temporal analysis of populations of the sudden

--- a/poppr/R/internal.r
+++ b/poppr/R/internal.r
@@ -151,7 +151,7 @@ NULL
 #'   Niklaus J. Grünwald. 2014. Sudden_Oak_Death_in_Oregon_Forests: Spatial and 
 #'   temporal population dynamics of the sudden oak death epidemic in Oregon 
 #'   Forests. ZENODO, doi:
-#'   \href{http://doi.org/10.5281/zenodo.13007}{10.5281/zenodo.13007}
+#'   \href{https://doi.org/10.5281/zenodo.13007}{10.5281/zenodo.13007}
 #'   
 #'   Goss, E. M., Larsen, M., Chastagner, G. A., Givens, D. R., and Grünwald, N.
 #'   J. 2009. Population genetic analysis infers migration pathways of 

--- a/quanteda/R/textmodel-wordfish.R
+++ b/quanteda/R/textmodel-wordfish.R
@@ -75,7 +75,7 @@ setClass("textmodel_wordfish_predicted",
 #'   
 #'   Lowe, Will and Kenneth Benoit. 2013. "Validating Estimates of Latent Traits
 #'   from Textual Data Using Human Judgment as a Benchmark." \emph{Political Analysis}
-#'   21(3), 298-313. \url{http://doi.org/10.1093/pan/mpt002}
+#'   21(3), 298-313. \url{https://doi.org/10.1093/pan/mpt002}
 #' @author Benjamin Lauderdale and Kenneth Benoit
 #' @examples
 #' textmodel_wordfish(LBGexample, dir = c(1,5))

--- a/smcfcs/R/smcfcs.r
+++ b/smcfcs/R/smcfcs.r
@@ -184,7 +184,7 @@
 #'
 #' @references Bartlett JW, Seaman SR, White IR, Carpenter JR. Multiple imputation of covariates
 #' by fully conditional specification: accommodating the substantive model. Statistical Methods
-#' in Medical Research 2015; 24(4): 462-487. \url{http://doi.org/10.1177/0962280214521348}
+#' in Medical Research 2015; 24(4): 462-487. \url{https://doi.org/10.1177/0962280214521348}
 
 #' @import stats
 

--- a/water/R/water_netRadiation.G.R
+++ b/water/R/water_netRadiation.G.R
@@ -451,8 +451,8 @@ albedo <- function(image.SR, aoi, coeff="Tasumi"){
 #' @author Fernando Fuentes Peñailillo
 #' @references 
 #' R. G. Allen, M. Tasumi, and R. Trezza, "Satellite-based energy balance for mapping evapotranspiration with internalized calibration (METRIC) - Model" Journal of Irrigation and Drainage Engineering, vol. 133, p. 380, 2007 \cr
-#' Carrasco-Benavides, M., Ortega-Farias, S., Lagos, L., Kleissl, J., Morales-Salinas, L., & Kilic, A. (2014). Parameterization of the Satellite-Based Model (METRIC) for the Estimation of Instantaneous Surface Energy Balance Components over a Drip-Irrigated Vineyard. Remote Sensing, 6(11), 11342-11371. http://doi.org/10.3390/rs61111342\cr
-#' Johnson, L. F. (2003). Temporal Stability of the NDVI-LAI Relationship in a Napa Valley Vineyard, 96-101. http://doi.org/10.1111/j.1755-0238.2003.tb00258.x
+#' Carrasco-Benavides, M., Ortega-Farias, S., Lagos, L., Kleissl, J., Morales-Salinas, L., & Kilic, A. (2014). Parameterization of the Satellite-Based Model (METRIC) for the Estimation of Instantaneous Surface Energy Balance Components over a Drip-Irrigated Vineyard. Remote Sensing, 6(11), 11342-11371. https://doi.org/10.3390/rs61111342\cr
+#' Johnson, L. F. (2003). Temporal Stability of the NDVI-LAI Relationship in a Napa Valley Vineyard, 96-101. https://doi.org/10.1111/j.1755-0238.2003.tb00258.x
 #' @export
 ## Cite Pocas work for LAI from METRIC2010
 LAI <- function(method="metric2010", image, aoi, L=0.1){

--- a/webchem/R/opsin.R
+++ b/webchem/R/opsin.R
@@ -11,7 +11,7 @@
 #'
 #' @references Lowe, D. M., Corbett, P. T., Murray-Rust, P., & Glen, R. C. (2011).
 #' Chemical Name to Structure: OPSIN, an Open Source Solution. Journal of Chemical Information and Modeling,
-#' 51(3), 739–753. http://doi.org/10.1021/ci100384d
+#' 51(3), 739–753. https://doi.org/10.1021/ci100384d
 #' @examples
 #' \donttest{
 #' opsin_query('Cyclopropane')

--- a/webchem/R/utils.R
+++ b/webchem/R/utils.R
@@ -300,7 +300,7 @@ extr_num <- function(x) {
 #' @author Eduard Szoecs, \email{eduardszoecs@@gmail.com}
 #' @references Grabner, M., Varmuza, K., & Dehmer, M. (2012). RMol:
 #' a toolset for transforming SD/Molfile structure information into R objects.
-#' Source Code for Biology and Medicine, 7, 12. http://doi.org/10.1186/1751-0473-7-12
+#' Source Code for Biology and Medicine, 7, 12. https://doi.org/10.1186/1751-0473-7-12
 #' @export
 
 parse_mol <- function(string) {


### PR DESCRIPTION
Hello!

The DOI foundation recommends [to use `https://doi.org`](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by changing all static DOI links accordingly.

Cheers :-)